### PR TITLE
API 문서화 기능을 추가합니다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation "io.springfox:springfox-boot-starter:3.0.0"
 }
 
 test {

--- a/src/main/java/com/kurly/common/config/SwaggerConfig.java
+++ b/src/main/java/com/kurly/common/config/SwaggerConfig.java
@@ -1,0 +1,32 @@
+package com.kurly.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+
+@Configuration
+public class SwaggerConfig {
+    private static final String BASE_PACKAGE = "com.kurly";
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.OAS_30)
+                .apiInfo(apiInfo())
+                .select()
+                .apis(RequestHandlerSelectors.basePackage(BASE_PACKAGE))
+                .paths(PathSelectors.any())
+                .build();
+    }
+
+    private ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title("PROMOTION")
+                .version("1.0.0")
+                .build();
+    }
+}


### PR DESCRIPTION
- api 문서화를 위한 도구로 Swagger를 의존성에 추가했습니다.

### 사용방법
프로젝트 실행후 http://localhost:8080/swagger-ui

문서의 주석이 필요한 경우 Swagger 문서를 참고하여 주석을 작성.
``` java
@RestController
public class HelloController {

    @GetMapping(value = "/hello")
    @ApiOperation(value = "hello, world", notes = "hello world")
    public String hello(){
        return "hello";
    }
}

```
문서 작성방법
> https://www.baeldung.com/spring-rest-openapi-documentation

###  장점 
- swagger를 사용하면 프로젝트내 API URI를 기반으로 자동으로 API 문서를 만들 수 있습니다.
- API 문서에서 POSTMAN처럼 API 기능 테스트를 할 수 있다는 점이 장점입니다.
- 현재 팀원들이 REST TEST를 BDD를 기반으로한 테스트에 익숙합니다.  
   BDD 스타일을 Spring REST DOCS 요구사항에 맞추기 쉽지않습니다. 
   API 테스트 작성에 BDD 스타일을 유지하고 API 문서화를 적용하고자 하면 Swagger가 좋은 선택이 될 수 있다고 생각합니다.
- 설정과 사용하기가 간단하고, 테스트 코드를 작성하지 않고도 빠르게 API 문서를 작성할 수 있습니다.

### 단점
- 기능 설명을 위해 SWAGGER 주석을 달아야합니다.
- 스프링의 공식 프로젝트가 아닙니다

see also
> https://swagger.io/
> https://jojoldu.tistory.com/31