### PR TITLE
CORS설정을 글로벌로 설정하라 

### DIFF
--- a/src/main/java/com/kurly/common/config/CorsConfig.java
+++ b/src/main/java/com/kurly/common/config/CorsConfig.java
@@ -1,0 +1,22 @@
+package com.kurly.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry
+                .addMapping("/**")
+                .allowedMethods(
+                        "OPTIONS", "GET", "POST", "PUT", "PATCH", "DELETE"
+                )
+                .allowedOrigins(
+                        "http://localhost:3000",
+                        "https://kurly-lover.web.app"
+                );
+    }
+}

--- a/src/main/resources/http/cors-test.http
+++ b/src/main/resources/http/cors-test.http
@@ -1,0 +1,5 @@
+### CORS test: 상태코드 200을 응답해야 합니다.
+OPTIONS http://localhost:8080/discounts
+Origin: http://localhost:3000
+Access-Control-Request-Headers: Origin, Accept, Content-Type
+Access-Control-Request-Method: GET


### PR DESCRIPTION
CORS 설정을 글로벌로 할 수 있도록 설정을 추가했습니다.

See also
  - https://spring.io/guides/gs/rest-service-cors/