### PR TITLE
DS_Store를 트랙킹 되지 않도록 하라

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+### Mac OS ###
+.DS_Store
+
 HELP.md
 .gradle
 build/


### PR DESCRIPTION
Mac OS X에서만 사용되는 .DS_Store가 Git으로 Tracking되고 있습니다.
더 이상 Tracking되지 않도록 .gitignore에 추가했습니다.