### PR TITLE
쿠폰 발급 기능을 추가하라

### DIFF
--- a/src/main/java/com/kurly/coupon/application/CouponPolicyService.java
+++ b/src/main/java/com/kurly/coupon/application/CouponPolicyService.java
@@ -1,0 +1,40 @@
+package com.kurly.coupon.application;
+
+import com.kurly.coupon.application.factory.FactoryPolicies;
+import com.kurly.coupon.domain.policy.CouponPolicies;
+import com.kurly.coupon.domain.policy.CouponPolicy;
+import com.kurly.coupon.dto.CouponPolicyPublishData;
+import com.kurly.coupon.infra.CouponPolicyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class CouponPolicyService {
+    private static final String ALREADY_EXISTED_POLICY = "이미 존재하는 정책입니다.";
+
+    private final CouponPolicyRepository couponPolicyRepository;
+    private final FactoryPolicies factoryPolicies;
+
+    @Transactional
+    public Long publishCouponPolicy(CouponPolicyPublishData dto) {
+        checkCouponDuplicated(dto);
+        final CouponPolicy couponPolicy = factoryPolicies.publishPolicy(dto);
+        final CouponPolicy savedPolicy = couponPolicyRepository.save(couponPolicy);
+        return savedPolicy.getId();
+    }
+
+    private void checkCouponDuplicated(CouponPolicyPublishData dto) {
+        final CouponPolicies couponPolicies = findPolicies(dto);
+        if (couponPolicies.isKeywordDuplicated(dto.convertKeywordVO()) ||
+                couponPolicies.isNameDuplicated(dto.convertNameVO())) {
+            throw new IllegalArgumentException(ALREADY_EXISTED_POLICY);
+        }
+    }
+
+    private CouponPolicies findPolicies(CouponPolicyPublishData dto) {
+        return new CouponPolicies(couponPolicyRepository.findByNameOrKeyword(dto.convertNameVO(), dto.convertKeywordVO()));
+    }
+}

--- a/src/main/java/com/kurly/coupon/application/CouponService.java
+++ b/src/main/java/com/kurly/coupon/application/CouponService.java
@@ -21,7 +21,7 @@ public class CouponService {
     @Transactional
     public Long issueCoupon(CouponIssueData dto) {
         Optional<Coupon> foundCoupon = findCoupon(dto);
-        if (findCoupon(dto).isPresent()) {
+        if (foundCoupon.isPresent()) {
             return increaseCouponCount(dto, foundCoupon.get());
         }
         final Coupon coupon = couponFactory.issueCoupon(dto);

--- a/src/main/java/com/kurly/coupon/application/CouponService.java
+++ b/src/main/java/com/kurly/coupon/application/CouponService.java
@@ -1,8 +1,8 @@
 package com.kurly.coupon.application;
 
 import com.kurly.coupon.application.factory.FactoryPolicies;
-import com.kurly.coupon.domain.CouponPolicies;
-import com.kurly.coupon.domain.CouponPolicy;
+import com.kurly.coupon.domain.policy.CouponPolicies;
+import com.kurly.coupon.domain.policy.CouponPolicy;
 import com.kurly.coupon.dto.CouponPolicyPublishData;
 import com.kurly.coupon.infra.CouponPolicyRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/kurly/coupon/application/CouponService.java
+++ b/src/main/java/com/kurly/coupon/application/CouponService.java
@@ -20,9 +20,9 @@ public class CouponService {
 
     @Transactional
     public Long issueCoupon(CouponIssueData dto) {
-        Optional<Coupon> findCoupon = findCoupon(dto);
+        Optional<Coupon> foundCoupon = findCoupon(dto);
         if (findCoupon(dto).isPresent()) {
-            return increaseCouponCount(dto, findCoupon.get());
+            return increaseCouponCount(dto, foundCoupon.get());
         }
         final Coupon coupon = couponFactory.issueCoupon(dto);
         final Coupon saved = couponRepository.save(coupon);

--- a/src/main/java/com/kurly/coupon/application/exception/PolicyNotFoundException.java
+++ b/src/main/java/com/kurly/coupon/application/exception/PolicyNotFoundException.java
@@ -1,0 +1,19 @@
+package com.kurly.coupon.application.exception;
+
+public class PolicyNotFoundException extends RuntimeException {
+    public PolicyNotFoundException() {
+        super();
+    }
+
+    public PolicyNotFoundException(String message) {
+        super(message);
+    }
+
+    public PolicyNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public PolicyNotFoundException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/kurly/coupon/application/factory/CouponFactory.java
+++ b/src/main/java/com/kurly/coupon/application/factory/CouponFactory.java
@@ -1,0 +1,33 @@
+package com.kurly.coupon.application.factory;
+
+import com.kurly.coupon.application.exception.PolicyNotFoundException;
+import com.kurly.coupon.domain.coupon.Coupon;
+import com.kurly.coupon.domain.coupon.CouponCount;
+import com.kurly.coupon.domain.policy.CouponPolicy;
+import com.kurly.coupon.domain.policy.Keyword;
+import com.kurly.coupon.dto.CouponIssueData;
+import com.kurly.coupon.infra.CouponPolicyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class CouponFactory {
+    private static final String NOT_FOUND_KEYWORD = "찾을 수 없는 키워드 : ";
+
+    private final CouponPolicyRepository couponPolicyRepository;
+
+    public Coupon issueCoupon(CouponIssueData dto) {
+        final Keyword keyword = Keyword.valueOf(dto.getKeyword());
+        final CouponPolicy policy = findPolicy(keyword);
+        final CouponCount count = CouponCount.valueOf(dto.getCount());
+
+        return Coupon.issueCoupon(policy, dto.getUserId(), count);
+    }
+
+    private CouponPolicy findPolicy(Keyword keyword) {
+        return couponPolicyRepository.findByKeyword(keyword)
+                .orElseThrow(() -> new PolicyNotFoundException(NOT_FOUND_KEYWORD + keyword));
+    }
+
+}

--- a/src/main/java/com/kurly/coupon/application/factory/FactoryPolicies.java
+++ b/src/main/java/com/kurly/coupon/application/factory/FactoryPolicies.java
@@ -1,6 +1,6 @@
 package com.kurly.coupon.application.factory;
 
-import com.kurly.coupon.domain.CouponPolicy;
+import com.kurly.coupon.domain.policy.CouponPolicy;
 import com.kurly.coupon.dto.CouponPolicyPublishData;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/kurly/coupon/application/factory/FixedAmountPolicyFactory.java
+++ b/src/main/java/com/kurly/coupon/application/factory/FixedAmountPolicyFactory.java
@@ -1,13 +1,13 @@
 package com.kurly.coupon.application.factory;
 
 import com.kurly.coupon.domain.policy.Amount;
-import com.kurly.coupon.domain.policy.Count;
 import com.kurly.coupon.domain.policy.CouponPolicy;
 import com.kurly.coupon.domain.policy.Keyword;
 import com.kurly.coupon.domain.policy.MinimumRedeemPrice;
 import com.kurly.coupon.domain.policy.Name;
 import com.kurly.coupon.domain.policy.Period;
 import com.kurly.coupon.domain.policy.PolicyType;
+import com.kurly.coupon.domain.policy.TotalCount;
 import com.kurly.coupon.dto.CouponPolicyPublishData;
 
 import java.util.Objects;
@@ -25,9 +25,9 @@ public class FixedAmountPolicyFactory implements PolicyFactory {
         final Period period = Period.createPeriod(dto.getStartDate(), dto.getEndDate());
         final Name name = Name.valueOf(dto.getName());
         final Amount amount = Amount.valueOf(dto.getAmount());
-        final Count count = Count.valueOf(dto.getCount());
+        final TotalCount totalCount = TotalCount.valueOf(dto.getCount());
         final MinimumRedeemPrice minimumRedeemPrice = MinimumRedeemPrice.valueOf(dto.getMinimumRedeemPrice());
 
-        return CouponPolicy.publishFixedAmountPolicy(name, keyword, period, amount, count, minimumRedeemPrice);
+        return CouponPolicy.publishFixedAmountPolicy(name, keyword, period, amount, totalCount, minimumRedeemPrice);
     }
 }

--- a/src/main/java/com/kurly/coupon/application/factory/FixedAmountPolicyFactory.java
+++ b/src/main/java/com/kurly/coupon/application/factory/FixedAmountPolicyFactory.java
@@ -1,13 +1,13 @@
 package com.kurly.coupon.application.factory;
 
-import com.kurly.coupon.domain.Amount;
-import com.kurly.coupon.domain.Count;
-import com.kurly.coupon.domain.CouponPolicy;
-import com.kurly.coupon.domain.Keyword;
-import com.kurly.coupon.domain.MinimumRedeemPrice;
-import com.kurly.coupon.domain.Name;
-import com.kurly.coupon.domain.Period;
-import com.kurly.coupon.domain.PolicyType;
+import com.kurly.coupon.domain.policy.Amount;
+import com.kurly.coupon.domain.policy.Count;
+import com.kurly.coupon.domain.policy.CouponPolicy;
+import com.kurly.coupon.domain.policy.Keyword;
+import com.kurly.coupon.domain.policy.MinimumRedeemPrice;
+import com.kurly.coupon.domain.policy.Name;
+import com.kurly.coupon.domain.policy.Period;
+import com.kurly.coupon.domain.policy.PolicyType;
 import com.kurly.coupon.dto.CouponPolicyPublishData;
 
 import java.util.Objects;

--- a/src/main/java/com/kurly/coupon/application/factory/FlatRatePolicyFactory.java
+++ b/src/main/java/com/kurly/coupon/application/factory/FlatRatePolicyFactory.java
@@ -1,13 +1,13 @@
 package com.kurly.coupon.application.factory;
 
-import com.kurly.coupon.domain.Count;
-import com.kurly.coupon.domain.CouponPolicy;
-import com.kurly.coupon.domain.Keyword;
-import com.kurly.coupon.domain.MinimumRedeemPrice;
-import com.kurly.coupon.domain.Name;
-import com.kurly.coupon.domain.Period;
-import com.kurly.coupon.domain.PolicyType;
-import com.kurly.coupon.domain.Rate;
+import com.kurly.coupon.domain.policy.Count;
+import com.kurly.coupon.domain.policy.CouponPolicy;
+import com.kurly.coupon.domain.policy.Keyword;
+import com.kurly.coupon.domain.policy.MinimumRedeemPrice;
+import com.kurly.coupon.domain.policy.Name;
+import com.kurly.coupon.domain.policy.Period;
+import com.kurly.coupon.domain.policy.PolicyType;
+import com.kurly.coupon.domain.policy.Rate;
 import com.kurly.coupon.dto.CouponPolicyPublishData;
 
 import java.util.Objects;

--- a/src/main/java/com/kurly/coupon/application/factory/FlatRatePolicyFactory.java
+++ b/src/main/java/com/kurly/coupon/application/factory/FlatRatePolicyFactory.java
@@ -1,6 +1,5 @@
 package com.kurly.coupon.application.factory;
 
-import com.kurly.coupon.domain.policy.Count;
 import com.kurly.coupon.domain.policy.CouponPolicy;
 import com.kurly.coupon.domain.policy.Keyword;
 import com.kurly.coupon.domain.policy.MinimumRedeemPrice;
@@ -8,6 +7,7 @@ import com.kurly.coupon.domain.policy.Name;
 import com.kurly.coupon.domain.policy.Period;
 import com.kurly.coupon.domain.policy.PolicyType;
 import com.kurly.coupon.domain.policy.Rate;
+import com.kurly.coupon.domain.policy.TotalCount;
 import com.kurly.coupon.dto.CouponPolicyPublishData;
 
 import java.util.Objects;
@@ -23,11 +23,11 @@ public class FlatRatePolicyFactory implements PolicyFactory {
     public CouponPolicy publishPolicy(CouponPolicyPublishData dto) {
         final Keyword keyword = Keyword.valueOf(dto.getKeyword());
         final Period period = Period.createPeriod(dto.getStartDate(), dto.getEndDate());
-        final Count count = Count.valueOf(dto.getCount());
+        final TotalCount totalCount = TotalCount.valueOf(dto.getCount());
         final Rate rate = Rate.valueOf(dto.getRate());
         final Name name = Name.valueOf(dto.getName());
         final MinimumRedeemPrice minimumRedeemPrice = MinimumRedeemPrice.valueOf(dto.getMinimumRedeemPrice());
 
-        return CouponPolicy.publishRatePolicy(name, keyword, period, rate, count, minimumRedeemPrice);
+        return CouponPolicy.publishRatePolicy(name, keyword, period, rate, totalCount, minimumRedeemPrice);
     }
 }

--- a/src/main/java/com/kurly/coupon/application/factory/PolicyFactory.java
+++ b/src/main/java/com/kurly/coupon/application/factory/PolicyFactory.java
@@ -1,7 +1,7 @@
 package com.kurly.coupon.application.factory;
 
-import com.kurly.coupon.domain.CouponPolicy;
-import com.kurly.coupon.domain.PolicyType;
+import com.kurly.coupon.domain.policy.CouponPolicy;
+import com.kurly.coupon.domain.policy.PolicyType;
 import com.kurly.coupon.dto.CouponPolicyPublishData;
 
 public interface PolicyFactory {

--- a/src/main/java/com/kurly/coupon/domain/coupon/Coupon.java
+++ b/src/main/java/com/kurly/coupon/domain/coupon/Coupon.java
@@ -2,6 +2,7 @@ package com.kurly.coupon.domain.coupon;
 
 import com.kurly.common.model.BaseEntity;
 import com.kurly.coupon.domain.policy.CouponPolicy;
+import com.kurly.coupon.domain.policy.Keyword;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -43,17 +44,31 @@ public class Coupon extends BaseEntity {
     @AttributeOverride(name = "value", column = @Column(name = "coupon_count", nullable = false))
     private CouponCount couponCount;
 
+    @Embedded
+    @AttributeOverride(name = "value", column = @Column(name = "keyword", nullable = false, unique = true))
+    private Keyword keyword;
+
     private Coupon(Long id, CouponPolicy couponPolicy, Long userId, CouponStatus couponStatus, CouponCount couponCount) {
         this.id = id;
         this.couponPolicy = couponPolicy;
         this.userId = userId;
         this.couponStatus = couponStatus;
         this.couponCount = couponCount;
+        this.keyword = Keyword.valueOf(couponPolicy.getKeyword());
     }
 
     public static Coupon issueCoupon(CouponPolicy couponPolicy, Long userId, CouponCount count) {
         couponPolicy.decreaseCount(count.getValue());
         return new Coupon(null, couponPolicy, userId, CouponStatus.ISSUED, count);
+    }
+
+    public void increaseCouponCount(Integer count) {
+        this.couponPolicy.decreaseCount(count);
+        this.couponCount = CouponCount.valueOf(getCouponCount() + count);
+    }
+
+    public Integer getCouponCount() {
+        return couponCount.getValue();
     }
 
     @Override

--- a/src/main/java/com/kurly/coupon/domain/coupon/Coupon.java
+++ b/src/main/java/com/kurly/coupon/domain/coupon/Coupon.java
@@ -6,6 +6,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.persistence.AttributeOverride;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
@@ -39,6 +40,7 @@ public class Coupon extends BaseEntity {
     private CouponStatus couponStatus;
 
     @Embedded
+    @AttributeOverride(name = "value", column = @Column(name = "coupon_count", nullable = false))
     private CouponCount couponCount;
 
     private Coupon(Long id, CouponPolicy couponPolicy, Long userId, CouponStatus couponStatus, CouponCount couponCount) {
@@ -50,7 +52,7 @@ public class Coupon extends BaseEntity {
     }
 
     public static Coupon issueCoupon(CouponPolicy couponPolicy, Long userId, CouponCount count) {
-        couponPolicy.subtractCount(count.getValue());
+        couponPolicy.decreaseCount(count.getValue());
         return new Coupon(null, couponPolicy, userId, CouponStatus.ISSUED, count);
     }
 

--- a/src/main/java/com/kurly/coupon/domain/coupon/Coupon.java
+++ b/src/main/java/com/kurly/coupon/domain/coupon/Coupon.java
@@ -64,7 +64,7 @@ public class Coupon extends BaseEntity {
 
     public void increaseCouponCount(Integer count) {
         this.couponPolicy.decreaseCount(count);
-        this.couponCount = CouponCount.valueOf(getCouponCount() + count);
+        this.couponCount = couponCount.increaseCount(count);
     }
 
     public Integer getCouponCount() {

--- a/src/main/java/com/kurly/coupon/domain/coupon/Coupon.java
+++ b/src/main/java/com/kurly/coupon/domain/coupon/Coupon.java
@@ -1,0 +1,69 @@
+package com.kurly.coupon.domain.coupon;
+
+import com.kurly.common.model.BaseEntity;
+import com.kurly.coupon.domain.policy.CouponPolicy;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Coupon extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "coupon_policy_id")
+    private CouponPolicy couponPolicy;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    private CouponStatus couponStatus;
+
+    @Embedded
+    private CouponCount couponCount;
+
+    private Coupon(Long id, CouponPolicy couponPolicy, Long userId, CouponStatus couponStatus, CouponCount couponCount) {
+        this.id = id;
+        this.couponPolicy = couponPolicy;
+        this.userId = userId;
+        this.couponStatus = couponStatus;
+        this.couponCount = couponCount;
+    }
+
+    public static Coupon issueCoupon(CouponPolicy couponPolicy, Long userId, CouponCount count) {
+        couponPolicy.subtractCount(count.getValue());
+        return new Coupon(null, couponPolicy, userId, CouponStatus.ISSUED, count);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Coupon)) return false;
+        Coupon coupon = (Coupon) o;
+        return Objects.equals(id, coupon.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/com/kurly/coupon/domain/coupon/CouponCount.java
+++ b/src/main/java/com/kurly/coupon/domain/coupon/CouponCount.java
@@ -27,6 +27,10 @@ public class CouponCount {
         return new CouponCount(value);
     }
 
+    public CouponCount increaseCount(Integer integer) {
+        return new CouponCount(this.value + integer);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/com/kurly/coupon/domain/coupon/CouponCount.java
+++ b/src/main/java/com/kurly/coupon/domain/coupon/CouponCount.java
@@ -1,4 +1,4 @@
-package com.kurly.coupon.domain.policy;
+package com.kurly.coupon.domain.coupon;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -10,28 +10,28 @@ import java.util.Objects;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Embeddable
-public class Count {
+public class CouponCount {
     private static final int MINIMUM_AMOUNT = 0;
     private static final String MINIMUM_NUMBER_REQUIRED = "0보다 작은 값이 입력될 수 없습니다.";
 
     private Integer value;
 
-    private Count(Integer value) {
+    private CouponCount(Integer value) {
         this.value = value;
     }
 
-    public static Count valueOf(Integer value) {
+    public static CouponCount valueOf(Integer value) {
         if (value < MINIMUM_AMOUNT) {
             throw new IllegalArgumentException(MINIMUM_NUMBER_REQUIRED);
         }
-        return new Count(value);
+        return new CouponCount(value);
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Count)) return false;
-        Count count = (Count) o;
+        if (!(o instanceof CouponCount)) return false;
+        CouponCount count = (CouponCount) o;
         return Objects.equals(getValue(), count.getValue());
     }
 

--- a/src/main/java/com/kurly/coupon/domain/coupon/CouponCount.java
+++ b/src/main/java/com/kurly/coupon/domain/coupon/CouponCount.java
@@ -28,7 +28,7 @@ public class CouponCount {
     }
 
     public CouponCount increaseCount(Integer integer) {
-        return new CouponCount(this.value + integer);
+        return valueOf(this.value + integer);
     }
 
     @Override

--- a/src/main/java/com/kurly/coupon/domain/coupon/CouponStatus.java
+++ b/src/main/java/com/kurly/coupon/domain/coupon/CouponStatus.java
@@ -1,0 +1,5 @@
+package com.kurly.coupon.domain.coupon;
+
+public enum CouponStatus {
+    ISSUED, USED, EXPIRED
+}

--- a/src/main/java/com/kurly/coupon/domain/policy/Amount.java
+++ b/src/main/java/com/kurly/coupon/domain/policy/Amount.java
@@ -1,4 +1,4 @@
-package com.kurly.coupon.domain;
+package com.kurly.coupon.domain.policy;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -10,29 +10,29 @@ import java.util.Objects;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Embeddable
-public class MinimumRedeemPrice {
+public class Amount {
     private static final int MINIMUM_AMOUNT = 0;
     private static final String MINIMUM_NUMBER_REQUIRED = "0보다 작은 값이 입력될 수 없습니다.";
 
     private Integer value;
 
-    private MinimumRedeemPrice(Integer value) {
+    private Amount(Integer value) {
         this.value = value;
     }
 
-    public static MinimumRedeemPrice valueOf(Integer value) {
-        if (Objects.nonNull(value) && value < MINIMUM_AMOUNT) {
+    public static Amount valueOf(Integer value) {
+        if (value < MINIMUM_AMOUNT) {
             throw new IllegalArgumentException(MINIMUM_NUMBER_REQUIRED);
         }
-        return new MinimumRedeemPrice(value);
+        return new Amount(value);
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof MinimumRedeemPrice)) return false;
-        MinimumRedeemPrice that = (MinimumRedeemPrice) o;
-        return Objects.equals(getValue(), that.getValue());
+        if (!(o instanceof Amount)) return false;
+        Amount amount = (Amount) o;
+        return Objects.equals(getValue(), amount.getValue());
     }
 
     @Override

--- a/src/main/java/com/kurly/coupon/domain/policy/Count.java
+++ b/src/main/java/com/kurly/coupon/domain/policy/Count.java
@@ -1,4 +1,4 @@
-package com.kurly.coupon.domain;
+package com.kurly.coupon.domain.policy;
 
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/com/kurly/coupon/domain/policy/CouponPolicies.java
+++ b/src/main/java/com/kurly/coupon/domain/policy/CouponPolicies.java
@@ -1,4 +1,4 @@
-package com.kurly.coupon.domain;
+package com.kurly.coupon.domain.policy;
 
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/com/kurly/coupon/domain/policy/CouponPolicy.java
+++ b/src/main/java/com/kurly/coupon/domain/policy/CouponPolicy.java
@@ -1,4 +1,4 @@
-package com.kurly.coupon.domain;
+package com.kurly.coupon.domain.policy;
 
 import com.kurly.common.model.BaseEntity;
 import lombok.AccessLevel;

--- a/src/main/java/com/kurly/coupon/domain/policy/CouponPolicy.java
+++ b/src/main/java/com/kurly/coupon/domain/policy/CouponPolicy.java
@@ -68,7 +68,7 @@ public class CouponPolicy extends BaseEntity {
     }
 
     public void decreaseCount(int count) {
-        this.totalCount = TotalCount.valueOf(getTotalCount() - count);
+        this.totalCount = this.totalCount.decreaseCount(count);
     }
 
     public static CouponPolicy publishFixedAmountPolicy(Name name, Keyword keyword, Period period, Amount amount, TotalCount totalCount, MinimumRedeemPrice minimumRedeemPrice) {

--- a/src/main/java/com/kurly/coupon/domain/policy/CouponPolicy.java
+++ b/src/main/java/com/kurly/coupon/domain/policy/CouponPolicy.java
@@ -67,7 +67,7 @@ public class CouponPolicy extends BaseEntity {
         this.minimumRedeemPrice = minimumRedeemPrice;
     }
 
-    public void subtractCount(int count) {
+    public void decreaseCount(int count) {
         this.totalCount = TotalCount.valueOf(getTotalCount() - count);
     }
 

--- a/src/main/java/com/kurly/coupon/domain/policy/CouponPolicy.java
+++ b/src/main/java/com/kurly/coupon/domain/policy/CouponPolicy.java
@@ -49,8 +49,8 @@ public class CouponPolicy extends BaseEntity {
      * 수량.
      */
     @Embedded
-    @AttributeOverride(name = "value", column = @Column(name = "count", nullable = false))
-    private Count count;
+    @AttributeOverride(name = "value", column = @Column(name = "total_count", nullable = false))
+    private TotalCount totalCount;
 
     /**
      * 최소 적용 가격.
@@ -59,20 +59,24 @@ public class CouponPolicy extends BaseEntity {
     @AttributeOverride(name = "value", column = @Column(name = "min_redeem_price_"))
     private MinimumRedeemPrice minimumRedeemPrice;
 
-    public CouponPolicy(Name name, Keyword keyword, Period period, Count count, MinimumRedeemPrice minimumRedeemPrice) {
+    public CouponPolicy(Name name, Keyword keyword, Period period, TotalCount totalCount, MinimumRedeemPrice minimumRedeemPrice) {
         this.name = name;
         this.keyword = keyword;
         this.period = period;
-        this.count = count;
+        this.totalCount = totalCount;
         this.minimumRedeemPrice = minimumRedeemPrice;
     }
 
-    public static CouponPolicy publishFixedAmountPolicy(Name name, Keyword keyword, Period period, Amount amount, Count count, MinimumRedeemPrice minimumRedeemPrice) {
-        return new FixedAmount(name, keyword, period, amount, count, minimumRedeemPrice);
+    public void subtractCount(int count) {
+        this.totalCount = TotalCount.valueOf(getTotalCount() - count);
     }
 
-    public static CouponPolicy publishRatePolicy(Name name, Keyword keyword, Period period, Rate rate, Count count, MinimumRedeemPrice minimumRedeemPrice) {
-        return new FlatRate(name, keyword, period, rate, count, minimumRedeemPrice);
+    public static CouponPolicy publishFixedAmountPolicy(Name name, Keyword keyword, Period period, Amount amount, TotalCount totalCount, MinimumRedeemPrice minimumRedeemPrice) {
+        return new FixedAmount(name, keyword, period, amount, totalCount, minimumRedeemPrice);
+    }
+
+    public static CouponPolicy publishRatePolicy(Name name, Keyword keyword, Period period, Rate rate, TotalCount totalCount, MinimumRedeemPrice minimumRedeemPrice) {
+        return new FlatRate(name, keyword, period, rate, totalCount, minimumRedeemPrice);
     }
 
     public String getKeyword() {
@@ -83,8 +87,8 @@ public class CouponPolicy extends BaseEntity {
         return period;
     }
 
-    public Integer getCount() {
-        return count.getValue();
+    public Integer getTotalCount() {
+        return totalCount.getValue();
     }
 
     public String getName() {

--- a/src/main/java/com/kurly/coupon/domain/policy/FixedAmount.java
+++ b/src/main/java/com/kurly/coupon/domain/policy/FixedAmount.java
@@ -1,4 +1,4 @@
-package com.kurly.coupon.domain;
+package com.kurly.coupon.domain.policy;
 
 import javax.persistence.AttributeOverride;
 import javax.persistence.Column;

--- a/src/main/java/com/kurly/coupon/domain/policy/FixedAmount.java
+++ b/src/main/java/com/kurly/coupon/domain/policy/FixedAmount.java
@@ -20,8 +20,8 @@ public class FixedAmount extends CouponPolicy {
     @AttributeOverride(name = "value", column = @Column(name = "amount"))
     private Amount amount;
 
-    public FixedAmount(Name name, Keyword keyword, Period period, Amount amount, Count count, MinimumRedeemPrice minimumRedeemPrice) {
-        super(name, keyword, period, count, minimumRedeemPrice);
+    public FixedAmount(Name name, Keyword keyword, Period period, Amount amount, TotalCount totalCount, MinimumRedeemPrice minimumRedeemPrice) {
+        super(name, keyword, period, totalCount, minimumRedeemPrice);
         this.amount = amount;
     }
 

--- a/src/main/java/com/kurly/coupon/domain/policy/FlatRate.java
+++ b/src/main/java/com/kurly/coupon/domain/policy/FlatRate.java
@@ -1,4 +1,4 @@
-package com.kurly.coupon.domain;
+package com.kurly.coupon.domain.policy;
 
 import javax.persistence.AttributeOverride;
 import javax.persistence.Column;

--- a/src/main/java/com/kurly/coupon/domain/policy/FlatRate.java
+++ b/src/main/java/com/kurly/coupon/domain/policy/FlatRate.java
@@ -20,8 +20,8 @@ public class FlatRate extends CouponPolicy {
     @AttributeOverride(name = "value", column = @Column(name = "rate"))
     private Rate rate;
 
-    public FlatRate(Name name, Keyword keyword, Period period, Rate rate, Count count, MinimumRedeemPrice minimumRedeemPrice) {
-        super(name, keyword, period, count, minimumRedeemPrice);
+    public FlatRate(Name name, Keyword keyword, Period period, Rate rate, TotalCount totalCount, MinimumRedeemPrice minimumRedeemPrice) {
+        super(name, keyword, period, totalCount, minimumRedeemPrice);
         this.rate = rate;
     }
 

--- a/src/main/java/com/kurly/coupon/domain/policy/Keyword.java
+++ b/src/main/java/com/kurly/coupon/domain/policy/Keyword.java
@@ -1,4 +1,4 @@
-package com.kurly.coupon.domain;
+package com.kurly.coupon.domain.policy;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/kurly/coupon/domain/policy/MinimumRedeemPrice.java
+++ b/src/main/java/com/kurly/coupon/domain/policy/MinimumRedeemPrice.java
@@ -1,4 +1,4 @@
-package com.kurly.coupon.domain;
+package com.kurly.coupon.domain.policy;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -10,29 +10,29 @@ import java.util.Objects;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Embeddable
-public class Amount {
+public class MinimumRedeemPrice {
     private static final int MINIMUM_AMOUNT = 0;
     private static final String MINIMUM_NUMBER_REQUIRED = "0보다 작은 값이 입력될 수 없습니다.";
 
     private Integer value;
 
-    private Amount(Integer value) {
+    private MinimumRedeemPrice(Integer value) {
         this.value = value;
     }
 
-    public static Amount valueOf(Integer value) {
-        if (value < MINIMUM_AMOUNT) {
+    public static MinimumRedeemPrice valueOf(Integer value) {
+        if (Objects.nonNull(value) && value < MINIMUM_AMOUNT) {
             throw new IllegalArgumentException(MINIMUM_NUMBER_REQUIRED);
         }
-        return new Amount(value);
+        return new MinimumRedeemPrice(value);
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Amount)) return false;
-        Amount amount = (Amount) o;
-        return Objects.equals(getValue(), amount.getValue());
+        if (!(o instanceof MinimumRedeemPrice)) return false;
+        MinimumRedeemPrice that = (MinimumRedeemPrice) o;
+        return Objects.equals(getValue(), that.getValue());
     }
 
     @Override

--- a/src/main/java/com/kurly/coupon/domain/policy/Name.java
+++ b/src/main/java/com/kurly/coupon/domain/policy/Name.java
@@ -1,4 +1,4 @@
-package com.kurly.coupon.domain;
+package com.kurly.coupon.domain.policy;
 
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/com/kurly/coupon/domain/policy/Period.java
+++ b/src/main/java/com/kurly/coupon/domain/policy/Period.java
@@ -1,4 +1,4 @@
-package com.kurly.coupon.domain;
+package com.kurly.coupon.domain.policy;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/kurly/coupon/domain/policy/PolicyType.java
+++ b/src/main/java/com/kurly/coupon/domain/policy/PolicyType.java
@@ -1,4 +1,4 @@
-package com.kurly.coupon.domain;
+package com.kurly.coupon.domain.policy;
 
 public enum PolicyType {
     FLAT_RATE, FIXED_AMOUNT

--- a/src/main/java/com/kurly/coupon/domain/policy/Rate.java
+++ b/src/main/java/com/kurly/coupon/domain/policy/Rate.java
@@ -1,4 +1,4 @@
-package com.kurly.coupon.domain;
+package com.kurly.coupon.domain.policy;
 
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/com/kurly/coupon/domain/policy/TotalCount.java
+++ b/src/main/java/com/kurly/coupon/domain/policy/TotalCount.java
@@ -28,7 +28,7 @@ public class TotalCount {
     }
 
     public TotalCount decreaseCount(Integer value) {
-        return new TotalCount(this.value - value);
+        return valueOf(this.value - value);
     }
 
     @Override

--- a/src/main/java/com/kurly/coupon/domain/policy/TotalCount.java
+++ b/src/main/java/com/kurly/coupon/domain/policy/TotalCount.java
@@ -27,6 +27,9 @@ public class TotalCount {
         return new TotalCount(value);
     }
 
+    public TotalCount decreaseCount(Integer value) {
+        return new TotalCount(this.value - value);
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/com/kurly/coupon/domain/policy/TotalCount.java
+++ b/src/main/java/com/kurly/coupon/domain/policy/TotalCount.java
@@ -1,0 +1,50 @@
+package com.kurly.coupon.domain.policy;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class TotalCount {
+    private static final int MINIMUM_AMOUNT = 0;
+    private static final String MINIMUM_NUMBER_REQUIRED = "0보다 작은 값이 입력될 수 없습니다.";
+
+    private Integer value;
+
+    private TotalCount(Integer value) {
+        this.value = value;
+    }
+
+    public static TotalCount valueOf(Integer value) {
+        if (value < MINIMUM_AMOUNT) {
+            throw new IllegalArgumentException(MINIMUM_NUMBER_REQUIRED);
+        }
+        return new TotalCount(value);
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TotalCount)) return false;
+        TotalCount totalCount = (TotalCount) o;
+        return Objects.equals(getValue(), totalCount.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getValue());
+    }
+
+    @Override
+    public String toString() {
+        return "Count{" +
+                "value=" + value +
+                '}';
+    }
+}

--- a/src/main/java/com/kurly/coupon/dto/CouponIssueData.java
+++ b/src/main/java/com/kurly/coupon/dto/CouponIssueData.java
@@ -1,0 +1,25 @@
+package com.kurly.coupon.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor
+public class CouponIssueData {
+    @NotNull
+    private Long userId;
+    @NotNull
+    private String keyword;
+    @NotNull
+    private Integer count;
+
+    @Builder
+    public CouponIssueData(Long userId, String keyword, Integer count) {
+        this.userId = userId;
+        this.keyword = keyword;
+        this.count = count;
+    }
+}

--- a/src/main/java/com/kurly/coupon/dto/CouponPolicyPublishData.java
+++ b/src/main/java/com/kurly/coupon/dto/CouponPolicyPublishData.java
@@ -1,8 +1,8 @@
 package com.kurly.coupon.dto;
 
-import com.kurly.coupon.domain.Keyword;
-import com.kurly.coupon.domain.Name;
-import com.kurly.coupon.domain.PolicyType;
+import com.kurly.coupon.domain.policy.Keyword;
+import com.kurly.coupon.domain.policy.Name;
+import com.kurly.coupon.domain.policy.PolicyType;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/kurly/coupon/infra/CouponPolicyRepository.java
+++ b/src/main/java/com/kurly/coupon/infra/CouponPolicyRepository.java
@@ -6,7 +6,10 @@ import com.kurly.coupon.domain.policy.Name;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CouponPolicyRepository extends JpaRepository<CouponPolicy, Long> {
     List<CouponPolicy> findByNameOrKeyword(Name name, Keyword keyword);
+
+    Optional<CouponPolicy> findByKeyword(Keyword keyword);
 }

--- a/src/main/java/com/kurly/coupon/infra/CouponPolicyRepository.java
+++ b/src/main/java/com/kurly/coupon/infra/CouponPolicyRepository.java
@@ -1,8 +1,8 @@
 package com.kurly.coupon.infra;
 
-import com.kurly.coupon.domain.CouponPolicy;
-import com.kurly.coupon.domain.Keyword;
-import com.kurly.coupon.domain.Name;
+import com.kurly.coupon.domain.policy.CouponPolicy;
+import com.kurly.coupon.domain.policy.Keyword;
+import com.kurly.coupon.domain.policy.Name;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;

--- a/src/main/java/com/kurly/coupon/infra/CouponRepository.java
+++ b/src/main/java/com/kurly/coupon/infra/CouponRepository.java
@@ -1,0 +1,11 @@
+package com.kurly.coupon.infra;
+
+import com.kurly.coupon.domain.coupon.Coupon;
+import com.kurly.coupon.domain.policy.Keyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+    Optional<Coupon> findByUserIdAndKeyword(Long userId, Keyword keyword);
+}

--- a/src/main/java/com/kurly/coupon/ui/CouponController.java
+++ b/src/main/java/com/kurly/coupon/ui/CouponController.java
@@ -1,6 +1,8 @@
 package com.kurly.coupon.ui;
 
+import com.kurly.coupon.application.CouponPolicyService;
 import com.kurly.coupon.application.CouponService;
+import com.kurly.coupon.dto.CouponIssueData;
 import com.kurly.coupon.dto.CouponPolicyPublishData;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,11 +20,18 @@ import java.net.URI;
 @RequestMapping("/coupons")
 @RestController
 public class CouponController {
+    private final CouponPolicyService couponPolicyService;
     private final CouponService couponService;
 
     @PostMapping("/policies")
     public ResponseEntity<Void> publishCouponPolicy(@RequestBody @Valid CouponPolicyPublishData policyRegisterDto) {
         log.info("publish policy: {} ", policyRegisterDto);
-        return ResponseEntity.created(URI.create("/coupons/policies/" + couponService.publishCouponPolicy(policyRegisterDto))).build();
+        return ResponseEntity.created(URI.create("/coupons/policies/" + couponPolicyService.publishCouponPolicy(policyRegisterDto))).build();
+    }
+
+    @PostMapping("/issues")
+    public ResponseEntity<Void> issueCoupon(@RequestBody @Valid CouponIssueData couponIssueData) {
+        log.info("issue coupon: {} ", couponIssueData);
+        return ResponseEntity.created(URI.create("/coupons/issues/" + couponService.issueCoupon(couponIssueData))).build();
     }
 }

--- a/src/main/java/com/kurly/promotion/dto/DiscountRegistrationData.java
+++ b/src/main/java/com/kurly/promotion/dto/DiscountRegistrationData.java
@@ -2,6 +2,7 @@ package com.kurly.promotion.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
 
@@ -9,6 +10,7 @@ import javax.validation.constraints.NotNull;
  * 할인 등록 정보.
  */
 @Getter
+@NoArgsConstructor
 public class DiscountRegistrationData {
 
     @NotNull

--- a/src/test/java/com/kurly/coupon/application/CouponPolicyServiceTest.java
+++ b/src/test/java/com/kurly/coupon/application/CouponPolicyServiceTest.java
@@ -1,0 +1,114 @@
+package com.kurly.coupon.application;
+
+import com.kurly.coupon.application.factory.FactoryPolicies;
+import com.kurly.coupon.domain.policy.Amount;
+import com.kurly.coupon.domain.policy.CouponPolicy;
+import com.kurly.coupon.domain.policy.Keyword;
+import com.kurly.coupon.domain.policy.MinimumRedeemPrice;
+import com.kurly.coupon.domain.policy.Name;
+import com.kurly.coupon.domain.policy.Period;
+import com.kurly.coupon.domain.policy.PolicyType;
+import com.kurly.coupon.domain.policy.TotalCount;
+import com.kurly.coupon.dto.CouponPolicyPublishData;
+import com.kurly.coupon.infra.CouponPolicyRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class CouponPolicyServiceTest {
+    private CouponPolicyPublishData couponPolicyPublishData;
+    private CouponPolicyPublishData invalidCouponPolicyPublishData;
+
+    private CouponPolicyService couponPolicyService;
+
+    private CouponPolicyRepository couponPolicyRepository = mock(CouponPolicyRepository.class);
+
+    private String givenName;
+    private String givenKeyword;
+    private Period givenPeriod;
+    private Integer givenCount;
+    private Integer givenAmount;
+    private Integer givenPrice;
+    private CouponPolicy createdPolicy;
+
+    @BeforeEach
+    void setUp() {
+        givenName = "테스트 쿠폰";
+        givenKeyword = "여름할인";
+        LocalDate givenStartDate = LocalDate.of(2030, 1, 1);
+        LocalDate givenEndDate = LocalDate.of(2030, 12, 31);
+        givenPeriod = Period.createPeriod(givenStartDate, givenEndDate);
+        givenAmount = 1000;
+        givenCount = 100;
+        givenPrice = 10000;
+
+        couponPolicyPublishData = CouponPolicyPublishData.builder()
+                .name(givenName)
+                .amount(givenAmount)
+                .count(givenCount)
+                .policyType(PolicyType.FIXED_AMOUNT)
+                .startDate(givenStartDate)
+                .endDate(givenEndDate)
+                .minimumRedeemPrice(givenPrice)
+                .build();
+
+        invalidCouponPolicyPublishData = CouponPolicyPublishData.builder()
+                .build();
+
+        couponPolicyService = new CouponPolicyService(couponPolicyRepository, new FactoryPolicies());
+
+        createdPolicy = CouponPolicy.publishFixedAmountPolicy(
+                Name.valueOf(givenName),
+                Keyword.valueOf(givenKeyword),
+                givenPeriod,
+                Amount.valueOf(givenAmount),
+                TotalCount.valueOf(givenCount),
+                MinimumRedeemPrice.valueOf(givenPrice)
+        );
+        ReflectionTestUtils.setField(createdPolicy, "id", 1L);
+    }
+
+    @DisplayName("publishCouponPolicy는 쿠폰 정책을 등록합니다.")
+    @Test
+    void publish_with_valid_coupon_policy() {
+        // given
+        given(couponPolicyRepository.save(any(CouponPolicy.class)))
+                .willReturn(createdPolicy);
+
+        // when
+        final Long id = couponPolicyService.publishCouponPolicy(couponPolicyPublishData);
+
+        // then
+        assertThat(id).isEqualTo(1L);
+        verify(couponPolicyRepository).save(any(CouponPolicy.class));
+    }
+
+    @DisplayName("publishCouponPolicy는 올바르지 않은 정보가 입력되면 예외를 던집니다.")
+    @Test
+    void publish_with_invalid_coupon_policy() {
+        assertThatCode(() -> couponPolicyService.publishCouponPolicy(invalidCouponPolicyPublishData))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("publishCouponPolicy는 이미 정책이 등록이 되어있으면 예외를 던집니다.")
+    @Test
+    void publish_with_exist_coupon_policy() {
+        // given
+        given(couponPolicyRepository.findByNameOrKeyword(any(Name.class), any(Keyword.class)))
+                .willReturn(List.of(createdPolicy));
+
+        assertThatCode(() -> couponPolicyService.publishCouponPolicy(invalidCouponPolicyPublishData))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/kurly/coupon/application/CouponServiceTest.java
+++ b/src/test/java/com/kurly/coupon/application/CouponServiceTest.java
@@ -2,13 +2,13 @@ package com.kurly.coupon.application;
 
 import com.kurly.coupon.application.factory.FactoryPolicies;
 import com.kurly.coupon.domain.policy.Amount;
-import com.kurly.coupon.domain.policy.Count;
 import com.kurly.coupon.domain.policy.CouponPolicy;
 import com.kurly.coupon.domain.policy.Keyword;
 import com.kurly.coupon.domain.policy.MinimumRedeemPrice;
 import com.kurly.coupon.domain.policy.Name;
 import com.kurly.coupon.domain.policy.Period;
 import com.kurly.coupon.domain.policy.PolicyType;
+import com.kurly.coupon.domain.policy.TotalCount;
 import com.kurly.coupon.dto.CouponPolicyPublishData;
 import com.kurly.coupon.infra.CouponPolicyRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -73,7 +73,7 @@ class CouponServiceTest {
                 Keyword.valueOf(givenKeyword),
                 givenPeriod,
                 Amount.valueOf(givenAmount),
-                Count.valueOf(givenCount),
+                TotalCount.valueOf(givenCount),
                 MinimumRedeemPrice.valueOf(givenPrice)
         );
         ReflectionTestUtils.setField(createdPolicy, "id", 1L);

--- a/src/test/java/com/kurly/coupon/application/CouponServiceTest.java
+++ b/src/test/java/com/kurly/coupon/application/CouponServiceTest.java
@@ -1,14 +1,14 @@
 package com.kurly.coupon.application;
 
 import com.kurly.coupon.application.factory.FactoryPolicies;
-import com.kurly.coupon.domain.Amount;
-import com.kurly.coupon.domain.Count;
-import com.kurly.coupon.domain.CouponPolicy;
-import com.kurly.coupon.domain.Keyword;
-import com.kurly.coupon.domain.MinimumRedeemPrice;
-import com.kurly.coupon.domain.Name;
-import com.kurly.coupon.domain.Period;
-import com.kurly.coupon.domain.PolicyType;
+import com.kurly.coupon.domain.policy.Amount;
+import com.kurly.coupon.domain.policy.Count;
+import com.kurly.coupon.domain.policy.CouponPolicy;
+import com.kurly.coupon.domain.policy.Keyword;
+import com.kurly.coupon.domain.policy.MinimumRedeemPrice;
+import com.kurly.coupon.domain.policy.Name;
+import com.kurly.coupon.domain.policy.Period;
+import com.kurly.coupon.domain.policy.PolicyType;
 import com.kurly.coupon.dto.CouponPolicyPublishData;
 import com.kurly.coupon.infra.CouponPolicyRepository;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/com/kurly/coupon/application/factory/FactoryPoliciesTest.java
+++ b/src/test/java/com/kurly/coupon/application/factory/FactoryPoliciesTest.java
@@ -1,9 +1,9 @@
 package com.kurly.coupon.application.factory;
 
-import com.kurly.coupon.domain.CouponPolicy;
-import com.kurly.coupon.domain.FixedAmount;
-import com.kurly.coupon.domain.FlatRate;
-import com.kurly.coupon.domain.PolicyType;
+import com.kurly.coupon.domain.policy.CouponPolicy;
+import com.kurly.coupon.domain.policy.FixedAmount;
+import com.kurly.coupon.domain.policy.FlatRate;
+import com.kurly.coupon.domain.policy.PolicyType;
 import com.kurly.coupon.dto.CouponPolicyPublishData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/kurly/coupon/domain/coupon/CouponTest.java
+++ b/src/test/java/com/kurly/coupon/domain/coupon/CouponTest.java
@@ -1,0 +1,70 @@
+package com.kurly.coupon.domain.coupon;
+
+import com.kurly.coupon.domain.policy.Amount;
+import com.kurly.coupon.domain.policy.CouponPolicy;
+import com.kurly.coupon.domain.policy.Keyword;
+import com.kurly.coupon.domain.policy.MinimumRedeemPrice;
+import com.kurly.coupon.domain.policy.Name;
+import com.kurly.coupon.domain.policy.Period;
+import com.kurly.coupon.domain.policy.TotalCount;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CouponTest {
+    private CouponPolicy couponPolicy;
+
+    @BeforeEach
+    void setUp() {
+        couponPolicy = publishedCouponPolicy();
+    }
+
+    @DisplayName("쿠폰을 사용자에게 발급 할 수 있다")
+    @Test
+    void create() {
+        Long userId = 1L;
+        CouponCount count = CouponCount.valueOf(2);
+
+        Coupon actual = Coupon.issueCoupon(couponPolicy, userId, count);
+
+        assertThat(actual).isNotNull();
+    }
+
+    @DisplayName("쿠폰은 상태를 가진다")
+    @Test
+    void initial_status() {
+        final Long userId = 1L;
+        final CouponCount count = CouponCount.valueOf(2);
+
+        final Coupon actual = Coupon.issueCoupon(couponPolicy, userId, count);
+
+        assertThat(actual.getCouponStatus()).isNotNull();
+    }
+
+    @DisplayName("쿠폰이 발급되면 쿠폰정책으로 만들어진 총 갯수가 감소한다")
+    @Test
+    void subtract_total_count() {
+        final Long userId = 1L;
+        final CouponCount count = CouponCount.valueOf(2);
+
+        Coupon.issueCoupon(couponPolicy, userId, count);
+
+        assertThat(couponPolicy.getTotalCount()).isEqualTo(3);
+    }
+
+    private CouponPolicy publishedCouponPolicy() {
+        final Name name = Name.valueOf("test 쿠폰");
+        final Keyword keyword = Keyword.valueOf("test 키워드");
+        final LocalDate startDate = LocalDate.of(2030, 1, 1);
+        final LocalDate endDate = LocalDate.of(2030, 12, 31);
+        final Period period = Period.createPeriod(startDate, endDate);
+        final TotalCount totalCount = TotalCount.valueOf(5);
+        final MinimumRedeemPrice minimumRedeemPrice = MinimumRedeemPrice.valueOf(0);
+        final Amount amount = Amount.valueOf(500);
+        return CouponPolicy.publishFixedAmountPolicy(name, keyword, period, amount, totalCount, minimumRedeemPrice);
+    }
+}

--- a/src/test/java/com/kurly/coupon/domain/policy/AmountTest.java
+++ b/src/test/java/com/kurly/coupon/domain/policy/AmountTest.java
@@ -1,4 +1,4 @@
-package com.kurly.coupon.domain;
+package com.kurly.coupon.domain.policy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/com/kurly/coupon/domain/policy/CountTest.java
+++ b/src/test/java/com/kurly/coupon/domain/policy/CountTest.java
@@ -1,4 +1,4 @@
-package com.kurly.coupon.domain;
+package com.kurly.coupon.domain.policy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/com/kurly/coupon/domain/policy/CouponPoliciesTest.java
+++ b/src/test/java/com/kurly/coupon/domain/policy/CouponPoliciesTest.java
@@ -14,7 +14,7 @@ class CouponPoliciesTest {
         CouponPolicy couponPolicy = CouponPolicy.publishRatePolicy(
                 new Name(), new Keyword(),
                 new Period(), new Rate(),
-                new Count(), null
+                new TotalCount(), null
         );
         CouponPolicies couponPolicies = new CouponPolicies(List.of(couponPolicy));
 
@@ -28,7 +28,7 @@ class CouponPoliciesTest {
         final CouponPolicy couponPolicy = CouponPolicy.publishRatePolicy(
                 givenName, new Keyword(),
                 new Period(), new Rate(),
-                new Count(), null
+                new TotalCount(), null
         );
         final CouponPolicies couponPolicies = new CouponPolicies(List.of(couponPolicy));
 
@@ -42,7 +42,7 @@ class CouponPoliciesTest {
         final CouponPolicy couponPolicy = CouponPolicy.publishRatePolicy(
                 new Name(), givenKeyword,
                 new Period(), new Rate(),
-                new Count(), null
+                new TotalCount(), null
         );
         final CouponPolicies couponPolicies = new CouponPolicies(List.of(couponPolicy));
 

--- a/src/test/java/com/kurly/coupon/domain/policy/CouponPoliciesTest.java
+++ b/src/test/java/com/kurly/coupon/domain/policy/CouponPoliciesTest.java
@@ -1,4 +1,4 @@
-package com.kurly.coupon.domain;
+package com.kurly.coupon.domain.policy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/kurly/coupon/domain/policy/CouponPolicyTest.java
+++ b/src/test/java/com/kurly/coupon/domain/policy/CouponPolicyTest.java
@@ -14,7 +14,7 @@ class CouponPolicyTest {
     @Test
     void coupon_name() {
         final Name GIVEN_NAME = Name.valueOf("test");
-        final CouponPolicy couponPolicy = CouponPolicy.publishFixedAmountPolicy(GIVEN_NAME, new Keyword(), new Period(), new Amount(), new Count(), new MinimumRedeemPrice());
+        final CouponPolicy couponPolicy = CouponPolicy.publishFixedAmountPolicy(GIVEN_NAME, new Keyword(), new Period(), new Amount(), new TotalCount(), new MinimumRedeemPrice());
 
         assertThat(couponPolicy.getName()).isNotNull();
     }
@@ -23,7 +23,7 @@ class CouponPolicyTest {
     @Test
     void coupon_number() {
         final Keyword keyword = Keyword.valueOf("여름할인");
-        final CouponPolicy couponPolicy = CouponPolicy.publishFixedAmountPolicy(new Name(), keyword, new Period(), new Amount(), new Count(), new MinimumRedeemPrice());
+        final CouponPolicy couponPolicy = CouponPolicy.publishFixedAmountPolicy(new Name(), keyword, new Period(), new Amount(), new TotalCount(), new MinimumRedeemPrice());
         assertThat(couponPolicy.getKeyword()).isNotNull();
     }
 
@@ -34,7 +34,7 @@ class CouponPolicyTest {
         final LocalDate endDate = LocalDate.of(2030, 12, 31);
         final Period period = Period.createPeriod(startDate, endDate);
 
-        final CouponPolicy couponPolicy = CouponPolicy.publishFixedAmountPolicy(new Name(), new Keyword(), period, new Amount(), new Count(), new MinimumRedeemPrice());
+        final CouponPolicy couponPolicy = CouponPolicy.publishFixedAmountPolicy(new Name(), new Keyword(), period, new Amount(), new TotalCount(), new MinimumRedeemPrice());
 
         assertAll(
                 () -> assertThat(couponPolicy.getPeriod().getStartDate()).isNotNull(),
@@ -46,7 +46,7 @@ class CouponPolicyTest {
     @Test
     void minimum_order_price() {
         final MinimumRedeemPrice minimumRedeemPrice = MinimumRedeemPrice.valueOf(1000);
-        final CouponPolicy couponPolicy = CouponPolicy.publishFixedAmountPolicy(new Name(), new Keyword(), new Period(), new Amount(), new Count(), minimumRedeemPrice);
+        final CouponPolicy couponPolicy = CouponPolicy.publishFixedAmountPolicy(new Name(), new Keyword(), new Period(), new Amount(), new TotalCount(), minimumRedeemPrice);
 
         assertThat(couponPolicy.getMinimumRedeemPrice()).isEqualTo(1000);
     }
@@ -54,7 +54,7 @@ class CouponPolicyTest {
     @DisplayName("쿠폰정책은 정률 할인 정책을 가진다.")
     @Test
     void flat_policy() {
-        CouponPolicy couponPolicy = CouponPolicy.publishRatePolicy(new Name(), new Keyword(), new Period(), Rate.valueOf(50), new Count(), new MinimumRedeemPrice());
+        CouponPolicy couponPolicy = CouponPolicy.publishRatePolicy(new Name(), new Keyword(), new Period(), Rate.valueOf(50), new TotalCount(), new MinimumRedeemPrice());
 
         assertAll(
                 () -> assertThat(couponPolicy).isInstanceOf(FlatRate.class),
@@ -65,7 +65,7 @@ class CouponPolicyTest {
     @DisplayName("쿠폰정책은 정액 할인 정책을 가진다.")
     @Test
     void fix_policy() {
-        final CouponPolicy couponPolicy = CouponPolicy.publishFixedAmountPolicy(new Name(), new Keyword(), new Period(), Amount.valueOf(500), new Count(), new MinimumRedeemPrice());
+        final CouponPolicy couponPolicy = CouponPolicy.publishFixedAmountPolicy(new Name(), new Keyword(), new Period(), Amount.valueOf(500), new TotalCount(), new MinimumRedeemPrice());
         assertAll(
                 () -> assertThat(couponPolicy).isInstanceOf(FixedAmount.class),
                 () -> assertThat(couponPolicy.getAmount()).isEqualTo(500)
@@ -75,8 +75,8 @@ class CouponPolicyTest {
     @DisplayName("쿠폰정책에 쿠폰을 생성할 개수를 지정할 수 있다.")
     @Test
     void count() {
-        final CouponPolicy couponPolicy = CouponPolicy.publishFixedAmountPolicy(new Name(), new Keyword(), new Period(), new Amount(), Count.valueOf(5), new MinimumRedeemPrice());
+        final CouponPolicy couponPolicy = CouponPolicy.publishFixedAmountPolicy(new Name(), new Keyword(), new Period(), new Amount(), TotalCount.valueOf(5), new MinimumRedeemPrice());
 
-        assertThat(couponPolicy.getCount()).isEqualTo(5);
+        assertThat(couponPolicy.getTotalCount()).isEqualTo(5);
     }
 }

--- a/src/test/java/com/kurly/coupon/domain/policy/CouponPolicyTest.java
+++ b/src/test/java/com/kurly/coupon/domain/policy/CouponPolicyTest.java
@@ -1,4 +1,4 @@
-package com.kurly.coupon.domain;
+package com.kurly.coupon.domain.policy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/kurly/coupon/domain/policy/FixedAmountTest.java
+++ b/src/test/java/com/kurly/coupon/domain/policy/FixedAmountTest.java
@@ -1,4 +1,4 @@
-package com.kurly.coupon.domain;
+package com.kurly.coupon.domain.policy;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/kurly/coupon/domain/policy/FixedAmountTest.java
+++ b/src/test/java/com/kurly/coupon/domain/policy/FixedAmountTest.java
@@ -12,9 +12,9 @@ class FixedAmountTest {
         final Keyword keyword = Keyword.valueOf("여름할인");
         final Period period = new Period();
         final Amount amount = Amount.valueOf(100);
-        final Count count = Count.valueOf(100);
+        final TotalCount totalCount = TotalCount.valueOf(100);
         final MinimumRedeemPrice minimumRedeemPrice = MinimumRedeemPrice.valueOf(1000);
-        FixedAmount fixedAmount = new FixedAmount(name, keyword, period, amount, count, minimumRedeemPrice);
+        FixedAmount fixedAmount = new FixedAmount(name, keyword, period, amount, totalCount, minimumRedeemPrice);
 
         assertThat(fixedAmount.getAmount()).isNotNull();
     }

--- a/src/test/java/com/kurly/coupon/domain/policy/FlatRateTest.java
+++ b/src/test/java/com/kurly/coupon/domain/policy/FlatRateTest.java
@@ -1,4 +1,4 @@
-package com.kurly.coupon.domain;
+package com.kurly.coupon.domain.policy;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/kurly/coupon/domain/policy/FlatRateTest.java
+++ b/src/test/java/com/kurly/coupon/domain/policy/FlatRateTest.java
@@ -12,9 +12,9 @@ class FlatRateTest {
         final Keyword keyword = Keyword.valueOf("여름할인");
         final Period period = new Period();
         final Rate rate = Rate.valueOf(100);
-        final Count count = Count.valueOf(100);
+        final TotalCount totalCount = TotalCount.valueOf(100);
         final MinimumRedeemPrice minimumRedeemPrice = MinimumRedeemPrice.valueOf(1000);
-        final FlatRate flatRate = new FlatRate(name, keyword, period, rate, count, minimumRedeemPrice);
+        final FlatRate flatRate = new FlatRate(name, keyword, period, rate, totalCount, minimumRedeemPrice);
 
         assertThat(flatRate.getRate()).isNotNull();
     }

--- a/src/test/java/com/kurly/coupon/domain/policy/KeywordTest.java
+++ b/src/test/java/com/kurly/coupon/domain/policy/KeywordTest.java
@@ -1,4 +1,4 @@
-package com.kurly.coupon.domain;
+package com.kurly.coupon.domain.policy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/kurly/coupon/domain/policy/MinimumRedeemPriceTest.java
+++ b/src/test/java/com/kurly/coupon/domain/policy/MinimumRedeemPriceTest.java
@@ -1,4 +1,4 @@
-package com.kurly.coupon.domain;
+package com.kurly.coupon.domain.policy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/com/kurly/coupon/domain/policy/NameTest.java
+++ b/src/test/java/com/kurly/coupon/domain/policy/NameTest.java
@@ -1,4 +1,4 @@
-package com.kurly.coupon.domain;
+package com.kurly.coupon.domain.policy;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/com/kurly/coupon/domain/policy/PeriodTest.java
+++ b/src/test/java/com/kurly/coupon/domain/policy/PeriodTest.java
@@ -1,4 +1,4 @@
-package com.kurly.coupon.domain;
+package com.kurly.coupon.domain.policy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/kurly/coupon/domain/policy/PolicyTypeTest.java
+++ b/src/test/java/com/kurly/coupon/domain/policy/PolicyTypeTest.java
@@ -1,4 +1,4 @@
-package com.kurly.coupon.domain;
+package com.kurly.coupon.domain.policy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/kurly/coupon/domain/policy/RateTest.java
+++ b/src/test/java/com/kurly/coupon/domain/policy/RateTest.java
@@ -1,4 +1,4 @@
-package com.kurly.coupon.domain;
+package com.kurly.coupon.domain.policy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/com/kurly/coupon/domain/policy/TotalCountTest.java
+++ b/src/test/java/com/kurly/coupon/domain/policy/TotalCountTest.java
@@ -7,19 +7,19 @@ import org.junit.jupiter.params.provider.ValueSource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-class CountTest {
+class TotalCountTest {
 
     @DisplayName("수량을 생성할 수 있다")
     @ParameterizedTest
     @ValueSource(ints = {1, 10, 100})
     void create(int givenCount) {
-        assertThat(Count.valueOf(givenCount)).isNotNull();
+        assertThat(TotalCount.valueOf(givenCount)).isNotNull();
     }
 
     @DisplayName("수량을 음수로 입력시 예외를 던진다.")
     @ParameterizedTest
     @ValueSource(ints = {-1, -10, -100})
     void create_with_negative_number(int givenCount) {
-        assertThatCode(() -> Count.valueOf(givenCount)).isInstanceOf(IllegalArgumentException.class);
+        assertThatCode(() -> TotalCount.valueOf(givenCount)).isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/com/kurly/coupon/ui/CouponControllerTest.java
+++ b/src/test/java/com/kurly/coupon/ui/CouponControllerTest.java
@@ -2,7 +2,7 @@ package com.kurly.coupon.ui;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kurly.coupon.application.CouponService;
-import com.kurly.coupon.domain.PolicyType;
+import com.kurly.coupon.domain.policy.PolicyType;
 import com.kurly.coupon.dto.CouponPolicyPublishData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/kurly/coupon/ui/CouponControllerTest.java
+++ b/src/test/java/com/kurly/coupon/ui/CouponControllerTest.java
@@ -1,8 +1,10 @@
 package com.kurly.coupon.ui;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kurly.coupon.application.CouponPolicyService;
 import com.kurly.coupon.application.CouponService;
 import com.kurly.coupon.domain.policy.PolicyType;
+import com.kurly.coupon.dto.CouponIssueData;
 import com.kurly.coupon.dto.CouponPolicyPublishData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -32,12 +34,18 @@ class CouponControllerTest {
     private ObjectMapper objectMapper;
 
     @MockBean
+    private CouponPolicyService couponPolicyService;
+
+    @MockBean
     private CouponService couponService;
 
     private CouponPolicyPublishData couponPolicyPublishData;
     private CouponPolicyPublishData invalidCouponPolicyPublishData;
+    private CouponIssueData couponIssueData;
+    private CouponIssueData invalidCouponIssueData;
 
-    private final Long registeredId = 1L;
+    private final Long policyRegisteredId = 1L;
+    private final Long couponRegisteredId = 1L;
 
     @BeforeEach
     void setUp() {
@@ -52,18 +60,27 @@ class CouponControllerTest {
                 .build();
 
         invalidCouponPolicyPublishData = new CouponPolicyPublishData();
+
+
+        couponIssueData = CouponIssueData.builder()
+                .count(1)
+                .userId(1L)
+                .keyword("test")
+                .build();
+
+        invalidCouponIssueData = new CouponIssueData();
     }
 
     @DisplayName("POST 요청은 올바른 쿠폰정책 정보가 주어진다면 상태코드 201 Created 를 응답한다.")
     @Test
     void publishWithValidCouponRegisterData() throws Exception {
-        given(couponService.publishCouponPolicy(any(CouponPolicyPublishData.class)))
-                .willReturn(registeredId);
+        given(couponPolicyService.publishCouponPolicy(any(CouponPolicyPublishData.class)))
+                .willReturn(policyRegisteredId);
 
         mockMvc.perform(post("/coupons/policies")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(couponPolicyPublishData)))
-                .andExpect(header().string("location", "/coupons/policies/" + registeredId))
+                .andExpect(header().string("location", "/coupons/policies/" + policyRegisteredId))
                 .andExpect(status().isCreated());
     }
 
@@ -73,6 +90,28 @@ class CouponControllerTest {
         mockMvc.perform(post("/coupons/policies")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(invalidCouponPolicyPublishData)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @DisplayName("POST 요청은 올바른 쿠폰 정보가 주어진다면 상태코드 201 Created 를 응답한다.")
+    @Test
+    void issueWithValidCouponIssueData() throws Exception {
+        given(couponService.issueCoupon(any(CouponIssueData.class)))
+                .willReturn(couponRegisteredId);
+
+        mockMvc.perform(post("/coupons/issues")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(couponIssueData)))
+                .andExpect(header().string("location", "/coupons/issues/" + couponRegisteredId))
+                .andExpect(status().isCreated());
+    }
+
+    @DisplayName("POST 요청은 올바르지 않은 쿠폰 정보가 주어진다면 상태코드 400 BadRequest 를 응답한다.")
+    @Test
+    void issueWithInValidCouponIsssueData() throws Exception {
+        mockMvc.perform(post("/coupons/issues")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidCouponIssueData)))
                 .andExpect(status().isBadRequest());
     }
 }


### PR DESCRIPTION
### Description
쿠폰 발급 기능을 추가합니다

### 테스트
http://localhost:8080/swagger-ui/
에 접속하여 테스트 가능합니다.

1. 쿠폰 정책을 발행합니다.
`/coupons/policies`
``` 
{
  "amount": 100,
  "count": 100,
  "endDate": "2021-10-24",
  "keyword": "aaa",
  "minimumRedeemPrice": 0,
  "name": "aaa",
  "policyType": "FIXED_AMOUNT",
  "rate": 0,
  "startDate": "2021-10-24"
}
```

2. 쿠폰 정책 발행후, 쿠폰을 발급합니다.
`/coupons/issues`

```
{
  "count": 20,
  "keyword": "aaa",
  "userId": 1
}
```


